### PR TITLE
[Feature] Convert ObjectId to string before returning user-svc data

### DIFF
--- a/.run/UserAPI.connections.e2e.run.xml
+++ b/.run/UserAPI.connections.e2e.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserAPI.connections.e2e" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />

--- a/.run/UserAPI.current.e2e.run.xml
+++ b/.run/UserAPI.current.e2e.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserAPI.current.e2e" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />

--- a/.run/UserAPI.e2e.run.xml
+++ b/.run/UserAPI.e2e.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserAPI.public.e2e" type="JavaScriptTestRunnerJest">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />
@@ -16,7 +16,7 @@
     <method v="2" />
   </configuration>
   <configuration default="false" name="UserAPI" type="JavaScriptTestRunnerJest">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />

--- a/.run/UserAPI_live.current.e2e.run.xml
+++ b/.run/UserAPI_live.current.e2e.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserAPI_live.current.e2e" type="JavaScriptTestRunnerJest">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />

--- a/.run/UserController.authorization.run.xml
+++ b/.run/UserController.authorization.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserController.authorization" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />

--- a/.run/UserController.crud.run.xml
+++ b/.run/UserController.crud.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserController.crud" type="JavaScriptTestRunnerJest">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />

--- a/.run/UserService.run.xml
+++ b/.run/UserService.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="UserService" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
-    <node-interpreter value="project" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />

--- a/apps/user-svc-e2e/src/user-svc/fixtures/validations.ts
+++ b/apps/user-svc-e2e/src/user-svc/fixtures/validations.ts
@@ -18,7 +18,7 @@ export const allValidations = [
     "children": [],
     "constraints": {
       "isString": "username must be a string",
-      "isLength": "username must be longer than or equal to 3 characters"
+      "isLength": "username must be longer than or equal to 2 characters"
     }
   },
   {
@@ -50,7 +50,6 @@ export const allValidations = [
     "property": "lastName",
     "children": [],
     "constraints": {
-      "isDefined": "lastName should not be null or undefined",
       "isString": "lastName must be a string",
       "isLength": "lastName must be longer than or equal to 2 characters"
     }

--- a/apps/user-svc-e2e/src/user-svc/user-svc.connections.spec.ts
+++ b/apps/user-svc-e2e/src/user-svc/user-svc.connections.spec.ts
@@ -125,7 +125,8 @@ describe('UserAPI.connections.e2e', () => {
               "children": [],
               "constraints": {
                 "isDefined": "userId should not be null or undefined",
-                "isMongoId": "userId must be a mongodb id"
+                "isString": "userId must be a string",
+                "isLength": "userId must be longer than or equal to 0 characters"
               }
             },
             {
@@ -138,7 +139,8 @@ describe('UserAPI.connections.e2e', () => {
               "children": [],
               "constraints": {
                 "isDefined": "connectionId should not be null or undefined",
-                "isMongoId": "connectionId must be a mongodb id"
+                "isString": "connectionId must be a string",
+                "isLength": "connectionId must be longer than or equal to 0 characters"
               }
             }
           ];
@@ -148,8 +150,8 @@ describe('UserAPI.connections.e2e', () => {
     });
   });
 
-  let uc1Id: ObjectId;
-  let uc2Id: ObjectId;
+  let uc1Id: string;
+  let uc2Id: string;
 
   describe('UserConnectionApi should create a first user connection', () => {
     it('should create a first user connection', async () => {

--- a/apps/user-svc/src/app/modules/user-connection/dto/create-user-connection.dto.ts
+++ b/apps/user-svc/src/app/modules/user-connection/dto/create-user-connection.dto.ts
@@ -1,3 +1,15 @@
-import { UserConnectionDto } from './user-connection.dto';
+import { AutoMap } from '@automapper/classes';
+import { ApiDecoratorOptions, ApiString } from '@mediashare/shared';
+import { IsDefined } from 'class-validator';
 
-export class CreateUserConnectionDto extends UserConnectionDto {}
+export class CreateUserConnectionDto {
+  @IsDefined()
+  @AutoMap()
+  @ApiString(<ApiDecoratorOptions>{ required: true })
+  userId: string;
+
+  @IsDefined()
+  @AutoMap()
+  @ApiString(<ApiDecoratorOptions>{ required: true })
+  connectionId: string;
+}

--- a/apps/user-svc/src/app/modules/user-connection/dto/user-connection.dto.ts
+++ b/apps/user-svc/src/app/modules/user-connection/dto/user-connection.dto.ts
@@ -1,34 +1,16 @@
 import { AutoMap } from '@automapper/classes';
-import { ApiDecoratorOptions, ApiObjectId, ApiPastDate } from '@mediashare/shared';
-import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsOptional } from 'class-validator';
-import { ObjectId } from 'mongodb';
+import { ApiBaseDto } from '@mediashare/core/dtos/base.dto';
+import { ApiDecoratorOptions, ApiString } from '@mediashare/shared';
+import { IsDefined } from 'class-validator';
 
-export class UserConnectionDto {
-  @IsOptional()
+export class UserConnectionDto extends ApiBaseDto {
+  @IsDefined()
   @AutoMap()
-  @ApiObjectId()
-  @ApiProperty({ required: false })
-  _id?: ObjectId;
+  @ApiString(<ApiDecoratorOptions>{ required: true })
+  userId: string;
 
   @IsDefined()
   @AutoMap()
-  @ApiObjectId()
-  @ApiProperty({ required: true })
-  userId: ObjectId;
-
-  @IsDefined()
-  @AutoMap()
-  @ApiObjectId()
-  @ApiProperty({ required: true })
-  connectionId: ObjectId;
-
-  @IsOptional()
-  @AutoMap()
-  @ApiPastDate({ required: false } as ApiDecoratorOptions)
-  createdAt?: Date;
-
-  @IsOptional()
-  @ApiPastDate({ required: false } as ApiDecoratorOptions)
-  updatedDate?: Date;
+  @ApiString(<ApiDecoratorOptions>{ required: true })
+  connectionId: string;
 }

--- a/apps/user-svc/src/app/modules/user-connection/entities/user-connection.entity.ts
+++ b/apps/user-svc/src/app/modules/user-connection/entities/user-connection.entity.ts
@@ -1,18 +1,18 @@
 import { AutoMap } from '@automapper/classes';
-import { Entity, Column } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
+import { AutoMapOptions } from '@automapper/classes/lib/automap';
+import { Entity, ObjectIdColumn } from 'typeorm';
 import { ApiBaseEntity } from '@mediashare/core/entities/base.entity';
 import { ObjectId } from 'mongodb';
 
 @Entity('user_connection')
 export class UserConnection extends ApiBaseEntity {
-  @AutoMap()
-  @ApiProperty()
-  @Column({ nullable: false })
+  @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
+  // Explicitly set the name option: https://github.com/typeorm/typeorm/issues/4026
+  @ObjectIdColumn({ name: 'userId', nullable: false })
   userId: ObjectId;
 
-  @AutoMap()
-  @ApiProperty()
-  @Column({ nullable: false })
+  @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
+  // Explicitly set the name option: https://github.com/typeorm/typeorm/issues/4026
+  @ObjectIdColumn({ name: 'connectionId', nullable: false })
   connectionId: ObjectId;
 }

--- a/apps/user-svc/src/app/modules/user-connection/mappers/automapper.profile.ts
+++ b/apps/user-svc/src/app/modules/user-connection/mappers/automapper.profile.ts
@@ -1,11 +1,39 @@
 /* istanbul ignore file */
+import { convertUsing, createMap, forMember, ignore, Mapper } from '@automapper/core';
 import { AutomapperProfile, InjectMapper } from '@automapper/nestjs';
-import { createMap, forMember, ignore, Mapper } from '@automapper/core';
+import { objectIdToStringConverter, stringToObjectIdConverter } from '@mediashare/core/mappings/converters';
 import { Injectable } from '@nestjs/common';
 import { UserConnection } from '../entities/user-connection.entity';
 import { CreateUserConnectionDto } from '../dto/create-user-connection.dto';
 import { UpdateUserConnectionDto } from '../dto/update-user-connection.dto';
 import { UserConnectionDto } from '../dto/user-connection.dto';
+
+export const connectionToConnectionDtoMappingFactory = (mapper) => createMap(
+  mapper,
+  UserConnection,
+  UserConnectionDto,
+  forMember((dest: UserConnectionDto) => dest._id, convertUsing(objectIdToStringConverter as never, (source: UserConnection) => source._id)),
+  forMember((dest: UserConnectionDto) => dest.userId, convertUsing(objectIdToStringConverter as never, (source: UserConnection) => source.userId)),
+  forMember((dest: UserConnectionDto) => dest.connectionId, convertUsing(objectIdToStringConverter as never, (source: UserConnection) => source.connectionId)),
+);
+
+export const createConnectionDtoToConnectionMappingFactory = (mapper) => createMap(
+  mapper,
+  CreateUserConnectionDto,
+  UserConnection,
+  forMember((dest: UserConnection) => dest._id, ignore()),
+  forMember((dest: UserConnection) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: UserConnectionDto) => source.userId)),
+  forMember((dest: UserConnection) => dest.connectionId, convertUsing(stringToObjectIdConverter as never, (source: UserConnectionDto) => source.connectionId)),
+);
+
+export const updateConnectionDtoToConnectionMappingFactory = (mapper) => createMap(
+  mapper,
+  UpdateUserConnectionDto,
+  UserConnection,
+  forMember((dest: UserConnection) => dest._id, convertUsing(stringToObjectIdConverter as never, (source: UserConnectionDto) => source._id)),
+  forMember((dest: UserConnection) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: UserConnectionDto) => source.userId)),
+  forMember((dest: UserConnection) => dest.connectionId, convertUsing(stringToObjectIdConverter as never, (source: UserConnectionDto) => source.connectionId)),
+);
 
 @Injectable()
 export class UserConnectionMapping extends AutomapperProfile {
@@ -15,9 +43,9 @@ export class UserConnectionMapping extends AutomapperProfile {
 
   override get profile() {
     return (mapper) => {
-      createMap(mapper, UserConnection, UserConnectionDto);
-      createMap(mapper, CreateUserConnectionDto, UserConnection, forMember((dest) => dest['_id'], ignore()));
-      createMap(mapper, UpdateUserConnectionDto, UserConnection);
+      connectionToConnectionDtoMappingFactory(mapper);
+      createConnectionDtoToConnectionMappingFactory(mapper);
+      updateConnectionDtoToConnectionMappingFactory(mapper);
     };
   }
 }

--- a/apps/user-svc/src/app/modules/user-connection/user-connection.service.ts
+++ b/apps/user-svc/src/app/modules/user-connection/user-connection.service.ts
@@ -50,14 +50,15 @@ export class UserConnectionService {
       throw new Error(msg);
     }
 
-    const rel1 = await this.classMapper.map({
-      userId: ObjectIdGuard(userId),
-      connectionId: ObjectIdGuard(connectionId),
-    }, CreateUserConnectionDto, UserConnection);
-    const rel2 = await this.classMapper.map({
-      userId: ObjectIdGuard(connectionId),
-      connectionId: ObjectIdGuard(userId),
-    }, CreateUserConnectionDto, UserConnection);
+    const rel1 = await this.classMapper.mapAsync({
+      userId: userId,
+      connectionId: connectionId,
+    } as CreateUserConnectionDto, CreateUserConnectionDto, UserConnection);
+
+    const rel2 = await this.classMapper.mapAsync({
+      userId: connectionId,
+      connectionId: userId,
+    } as CreateUserConnectionDto, CreateUserConnectionDto, UserConnection);
 
     await Promise.all([
       this.dataService.create(rel1),
@@ -77,7 +78,7 @@ export class UserConnectionService {
     const results = entities.map(async (entity) =>
       await this.classMapper.mapAsync(entity, UserConnection, UserConnectionDto));
 
-    return await Promise.all(results);
+    return Promise.all(results);
   }
 
   async remove({ userId, connectionId }: Partial<UserConnectionDto>): Promise<void> {

--- a/apps/user-svc/src/app/modules/user/dto/create-user.dto.ts
+++ b/apps/user-svc/src/app/modules/user/dto/create-user.dto.ts
@@ -1,52 +1,51 @@
 import { AutoMap } from '@automapper/classes';
-import { ApiDecoratorOptions, ApiEmail, ApiName, ApiString } from '@mediashare/shared';
+import { ApiEmail, ApiName, ApiString, ApiUriString } from '@mediashare/shared';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsOptional, IsEmail, IsString, Length, IsPhoneNumber } from 'class-validator';
+import { IsOptional, IsEmail, IsString, Length, IsPhoneNumber } from 'class-validator';
 import { BC_ROLES, BcRolesType } from '../../../core/models';
 
 export class CreateUserDto {
   @IsString()
   @AutoMap()
-  @ApiString()
+  @ApiString({ required: true })
   sub: string;
 
-  @Length(3, 50)
+  @Length(2, 50)
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   username: string;
 
   // Min is technically 3 but with real domain it's x@y.zz = 6
   // https://www.rfc-editor.org/rfc/rfc2822
-  @Length(6, 254)
+  @Length(6, 255)
   @IsEmail()
   @AutoMap()
-  @ApiEmail(<ApiDecoratorOptions>{ required: true })
+  @ApiEmail({ required: true })
   email: string;
 
   @Length(2, 50)
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   firstName: string;
 
   @Length(2, 50)
-  @IsDefined()
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   lastName: string;
 
   @IsOptional()
   @IsPhoneNumber()
   @AutoMap()
-  @ApiString()
+  @ApiString({ required: false })
   phoneNumber?: string;
 
   @IsOptional()
   @IsString()
   @AutoMap()
-  @ApiString()
+  @ApiUriString({ required: false })
   imageSrc?: string;
 
   @IsOptional()
@@ -56,6 +55,6 @@ export class CreateUserDto {
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   isDisabled?: boolean;
 }

--- a/apps/user-svc/src/app/modules/user/dto/update-user.dto.ts
+++ b/apps/user-svc/src/app/modules/user/dto/update-user.dto.ts
@@ -1,55 +1,47 @@
 import { AutoMap } from '@automapper/classes';
-import { ApiDecoratorOptions, ApiEmail, ApiName, ApiString } from '@mediashare/shared';
+import { ApiEmail, ApiName, ApiString, ApiUriString } from '@mediashare/shared';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsEmail, IsOptional, IsPhoneNumber, IsString, Length } from 'class-validator';
+import { IsEmail, IsOptional, IsPhoneNumber, IsString, Length } from 'class-validator';
+import { ApiBaseDto } from '@mediashare/core/dtos/base.dto';
 import { BC_ROLES, BcRolesType } from '../../../core/models';
 
-// TODO: Use a pick or something so we're not repeating ourselves
-// export class UpdateUserDto extends UserDto {}
-export class UpdateUserDto {
-  @IsOptional()
+export class UpdateUserDto extends ApiBaseDto {
+  @Length(2, 50)
   @IsString()
   @AutoMap()
-  @ApiString()
-  sub: string;
-
-  @Length(3, 50)
-  @IsString()
-  @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   username: string;
 
   // Min is technically 3 but with real domain it's x@y.zz = 6
   // https://www.rfc-editor.org/rfc/rfc2822
-  @Length(6, 254)
+  @Length(6, 255)
   @IsEmail()
   @AutoMap()
-  @ApiEmail(<ApiDecoratorOptions>{ required: true })
+  @ApiEmail({ required: true })
   email: string;
 
   @Length(2, 50)
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   firstName: string;
 
   @Length(2, 50)
-  @IsDefined()
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   lastName: string;
 
   @IsOptional()
   @IsPhoneNumber()
   @AutoMap()
-  @ApiString()
+  @ApiString({ required: false })
   phoneNumber?: string;
 
   @IsOptional()
   @IsString()
   @AutoMap()
-  @ApiString()
+  @ApiUriString({ required: false })
   imageSrc?: string;
 
   @IsOptional()
@@ -59,21 +51,21 @@ export class UpdateUserDto {
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   isDisabled?: boolean;
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   transactionId?: string;
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   transactionDate?: string;
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   transactionEndDate?: string;
 }

--- a/apps/user-svc/src/app/modules/user/dto/user.dto.ts
+++ b/apps/user-svc/src/app/modules/user/dto/user.dto.ts
@@ -1,58 +1,53 @@
 import { AutoMap } from '@automapper/classes'
-import { ApiDecoratorOptions, ApiEmail, ApiName, ApiObjectId, ApiPastDate, ApiString } from '@mediashare/shared';
+import { ApiEmail, ApiName, ApiString, ApiUriString } from '@mediashare/shared';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsDefined, IsEmail, IsOptional, IsPhoneNumber, IsString, Length } from 'class-validator';
-import { ObjectId } from 'mongodb';
+import { IsDefined, IsEmail, IsOptional, IsPhoneNumber, IsString, Length } from 'class-validator';
+import { ApiBaseDto } from '@mediashare/core/dtos/base.dto';
 import { BC_ROLES, BcRolesType } from '../../../core/models';
 
-export class UserDto {
-  @IsDefined()
-  @AutoMap()
-  @ApiObjectId()
-  _id: ObjectId;
-
+export class UserDto extends ApiBaseDto {
   @IsString()
   @AutoMap()
-  @ApiString()
+  @ApiString({ required: true })
   sub: string;
 
-  @Length(3, 50)
+  @Length(2, 50)
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   username: string;
 
   // Min is technically 3 but with real domain it's x@y.zz = 6
   // https://www.rfc-editor.org/rfc/rfc2822
-  @Length(6, 254)
+  @Length(6, 255)
   @IsEmail()
   @AutoMap()
-  @ApiEmail(<ApiDecoratorOptions>{ required: true })
+  @ApiEmail({ required: true })
   email: string;
 
   @Length(2, 50)
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   firstName: string;
 
   @Length(2, 50)
   @IsDefined()
   @IsString()
   @AutoMap()
-  @ApiName(<ApiDecoratorOptions>{ required: true })
+  @ApiName({ required: true })
   lastName: string;
 
   @IsOptional()
   @IsPhoneNumber()
   @AutoMap()
-  @ApiString()
+  @ApiString({ required: false })
   phoneNumber?: string;
 
   @IsOptional()
   @IsString()
   @AutoMap()
-  @ApiString()
+  @ApiUriString({ required: false })
   imageSrc?: string;
 
   @IsOptional()
@@ -62,33 +57,21 @@ export class UserDto {
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   isDisabled?: boolean;
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   transactionId?: string;
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   transactionDate?: string;
 
   @IsOptional()
   @AutoMap()
-  @ApiProperty()
+  @ApiProperty({ required: false })
   transactionEndDate?: string;
-
-  @IsOptional()
-  // @IsDate()
-  @AutoMap()
-  @ApiPastDate()
-  createdAt?: Date;
-
-  @IsOptional()
-  // @IsDate()
-  @AutoMap()
-  @ApiPastDate()
-  updatedDate?: Date;
 }

--- a/apps/user-svc/src/app/modules/user/entities/user.entity.ts
+++ b/apps/user-svc/src/app/modules/user/entities/user.entity.ts
@@ -1,84 +1,73 @@
 import { AutoMap } from '@automapper/classes';
-import { Entity, Column } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
+import { Entity, Column, BeforeInsert } from 'typeorm';
 import { ApiBaseEntity } from '@mediashare/core/entities/base.entity';
 import { BcRolesType, BC_ROLES } from '../../../core/models';
+import { ObjectId } from 'mongodb';
 
 @Entity('user')
 export class User extends ApiBaseEntity {
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: false })
   sub: string;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: false })
   username: string;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: false })
   email: string;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: false })
   firstName: string;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: false })
   lastName: string;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: true })
   phoneNumber: string;
 
   @AutoMap()
-  @ApiProperty()
+  @Column({ nullable: true })
+  imageSrc: string;
+
+  @AutoMap()
+  @Column({ enum: BC_ROLES, name: 'role', enumName: 'BcRolesType', nullable: true })
+  role: BcRolesType;
+
+  @AutoMap()
   @Column({ nullable: true })
   isDisabled: boolean;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: true })
   transactionId: string;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: true })
   transactionDate: string;
 
   @AutoMap()
-  @ApiProperty()
   @Column({ nullable: true })
   transactionEndDate: string;
 
-  @AutoMap()
-  @ApiProperty()
-  @Column({ nullable: true })
-  imageSrc: string;
-
-  /*
-  @AutoMap()
-  @ApiProperty({ isArray: true, nullable: true})
-  @Column({ array: true, nullable: true }) sharedPlaylists?: ObjectId[];
+  /* @AutoMap()
+  @Column({ array: true, nullable: true }) sharedPlaylists: ObjectId[];
 
   @AutoMap()
-  @ApiProperty({ isArray: true, nullable: true})
-  @Column({ array: true, nullable: true}) sharedMediaItems?: ObjectId[]; */
+  @Column({ array: true, nullable: true}) sharedMediaItems: ObjectId[];
 
   @AutoMap()
-  @ApiProperty()
-  @Column({ enum: BC_ROLES, name: 'role', enumName: 'BcRolesType' })
-  role: BcRolesType;
-
-  /*
-  @AutoMap()
-  @ApiProperty({ type: () => ShareItem, isArray: true, nullable: true })
   @OneToMany(() => ShareItem, (shareItem) => shareItem.userId)
   @Column({ array: true, nullable: true })
-  shareItem?: ShareItem[];*/
+  shareItem: ShareItem[];*/
+
+  @BeforeInsert()
+  setCreatedBy() {
+    // TODO: Use a db trigger
+    // this.createdBy = new ObjectId();
+  }
 }

--- a/apps/user-svc/src/app/modules/user/user.controller.spec.ts
+++ b/apps/user-svc/src/app/modules/user/user.controller.spec.ts
@@ -133,7 +133,7 @@ describe('UserController.crud', () => {
     });
 
     const data = {
-      _id: new ObjectId('649bf1b109d28ad4892f1548'),
+      _id: '649bf1b109d28ad4892f1548',
       sub: '33a08148-b658-403d-b070-cdc0f34e5274',
       username: 'demosubscriber',
       firstName: 'Lucas',

--- a/apps/user-svc/src/app/modules/user/user.controller.ts
+++ b/apps/user-svc/src/app/modules/user/user.controller.ts
@@ -205,7 +205,7 @@ export class UserController {
   @ApiBearerAuth()
   @Get('connections')
   @UserGetResponse({ type: UserDto, isArray: true }) // TODO: Use ProfileDto
-  async getCurrentUserConnections(@Res() res: Response, @GetUser('_id') userId: ObjectId) {
+  async getCurrentUserConnections(@Res() res: Response, @GetUser('_id') userId: string) {
     try {
       const userConnections = await this.userConnectionService.findConnections(userId);
       const connectionUserIds = userConnections.map((uc) => uc.connectionId)
@@ -225,10 +225,10 @@ export class UserController {
   async getUserConnections(@Res() res: Response, @Param('userId', ObjectIdPipe) userId: ObjectId) {
     try {
       const userConnections = await this.userConnectionService.findConnections(userId);
-      const connectionUserIds = userConnections.map((uc) => uc.connectionId)
+      const userConnectionIds = userConnections.map((uc) => uc.connectionId);
 
       // TODO: Use mapper in findByIds
-      const result = await this.userService.findByIds(connectionUserIds);
+      const result = await this.userService.findByIds(userConnectionIds);
       return handleSuccessResponse(res, HttpStatus.OK, result);
     } catch (error) {
       return handleErrorResponse(res, error);

--- a/libs/core/src/lib/dtos/base.dto.ts
+++ b/libs/core/src/lib/dtos/base.dto.ts
@@ -1,0 +1,25 @@
+import { AutoMap } from '@automapper/classes';
+import { ApiDecoratorOptions, ApiString } from '@mediashare/shared';
+import { ApiProperty,  } from '@nestjs/swagger';
+
+export interface IApiBaseDto {
+  _id: string;
+}
+
+export class ApiBaseDto implements IApiBaseDto {
+  @AutoMap()
+  @ApiString(<ApiDecoratorOptions>{ required: true })
+  _id: string;
+
+  // @AutoMap()
+  // @ApiString(<ApiDecoratorOptions>{ required: false })
+  // createdBy?: string;
+
+  @AutoMap()
+  @ApiProperty({ readOnly: true, type: Date, required: false })
+  readonly createdAt?: Date;
+
+  @AutoMap()
+  @ApiProperty({ readOnly: true, type: Date, required: false })
+  readonly updatedDate?: Date;
+}

--- a/libs/core/src/lib/entities/base.entity.ts
+++ b/libs/core/src/lib/entities/base.entity.ts
@@ -1,45 +1,40 @@
 import { AutoMap } from '@automapper/classes';
-import { ObjectId } from 'bson';
-import { ObjectIdColumn, Entity, CreateDateColumn, UpdateDateColumn, Column } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
-import { ApiDecoratorOptions, ApiObjectId, ApiPastDate } from '@mediashare/shared';
-import { IdType } from '@mediashare/shared';
+import { AutoMapOptions } from '@automapper/classes/lib/automap';
+import { ObjectIdColumn, Entity, CreateDateColumn, UpdateDateColumn, ColumnOptions } from 'typeorm';
+import { ObjectId } from 'mongodb';
 
-export interface ApiBaseEntityInterface {
-  _id: IdType;
+export interface IApiBaseEntity {
+  _id: ObjectId;
 }
 
-export abstract class DataProviderBaseEntity<M> implements ApiBaseEntityInterface {
+export abstract class DataProviderBaseEntity<M> implements IApiBaseEntity {
+  @AutoMap()
   @ObjectIdColumn()
-  _id: ObjectId | string;
+  _id: ObjectId;
 
   // TODO: Do we need to update this?
-  //  The constructor part needs to be looked at
-  //  and removed if unnecessary
+  //  The constructor part needs to be looked at!
+  //  Remove if unnecessary...
   protected constructor(model?: Partial<M>) {
     Object.assign(this, model);
   }
 }
 
 @Entity()
-export class ApiBaseEntity implements ApiBaseEntityInterface {
-  @AutoMap()
+export class ApiBaseEntity implements IApiBaseEntity {
+  @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
   @ObjectIdColumn()
-  @ApiObjectId(<ApiDecoratorOptions>{ readOnly: true })
   _id: ObjectId;
 
-  @AutoMap()
-  @Column()
-  @ApiObjectId()
-  readonly createdBy?: Readonly<ObjectId>;
+  // @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
+  // @ObjectIdColumn()
+  // createdBy: ObjectId;
 
   @AutoMap()
   @CreateDateColumn()
-  @ApiProperty({ readOnly: true, type: Date, required: true })
-  readonly createdAt?: Date;
+  readonly createdAt: Date;
 
   @AutoMap()
-  @UpdateDateColumn()
-  @ApiPastDate(<ApiDecoratorOptions>{ readOnly: true, type: Date, required: false })
-  readonly updatedDate?: Date;
+  @UpdateDateColumn(<ColumnOptions>{ required: false })
+  readonly updatedDate: Date;
 }

--- a/libs/core/src/lib/mappings/converters.ts
+++ b/libs/core/src/lib/mappings/converters.ts
@@ -1,0 +1,13 @@
+import { Converter } from '@automapper/types';
+import { ObjectId } from 'mongodb';
+
+export const objectIdToStringConverter: Converter<ObjectId, string> = {
+  convert(source) {
+    return source.toHexString();
+  }
+};
+export const stringToObjectIdConverter: Converter<string, ObjectId> = {
+  convert(source) {
+    return new ObjectId(source);
+  }
+};

--- a/libs/core/src/lib/services/filterable-data-provider.service.ts
+++ b/libs/core/src/lib/services/filterable-data-provider.service.ts
@@ -42,7 +42,7 @@ export abstract class FilterableDataService<E extends DataProviderBaseEntity<E>,
   } */
 
   // TODO: Finish this later... options could be Elastic, Mongo Atlas Search or Apache Lucene
-  protected get useDistributedSearch() {
+  get useDistributedSearch() {
     return false; // this.configService.get<string>('dbIsMongoAtlas');
   }
 

--- a/libs/shared/src/lib/decorators/api-string.decorator.ts
+++ b/libs/shared/src/lib/decorators/api-string.decorator.ts
@@ -1,6 +1,5 @@
 // @ApiProperty({ type: 'string' })
-
-import { ApiDecoratorType } from '@mediashare/shared';
+import { ApiDecoratorType } from '../models';
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, IsUrl, Length } from 'class-validator';
@@ -13,7 +12,7 @@ const lengthFn = function (minLength: number, maxLength: number) {
 };
 
 export const ApiEmail: ApiDecoratorType = function ({ required } = apiDecoratorDefaults) {
-  const length = [5, 50] as const;
+  const length = [6, 50] as const;
 
   return applyDecorators(
     ApiProperty({ required, type: String, example: 'test@example.com', ...lengthFn(...length) }),
@@ -26,7 +25,7 @@ export const ApiUsername: ApiDecoratorType = function ({ required } = apiDecorat
 };
 
 export const ApiName: ApiDecoratorType = function ({ required } = apiDecoratorDefaults) {
-  const length = [3, 30] as const;
+  const length = [2, 50] as const;
 
   return applyDecorators(
     ...baseStringValidators(...length),
@@ -54,7 +53,7 @@ export const ApiUriString: ApiDecoratorType = function ({ required } = apiDecora
     ApiProperty({
       required,
       type: String,
-      example: 'http://ihila.sh/ruabcos',
+      example: 'http://www.example.com',
       maxLength: max,
       minLength: min,
     })

--- a/libs/shared/src/lib/models/api-decorator.model.ts
+++ b/libs/shared/src/lib/models/api-decorator.model.ts
@@ -1,4 +1,3 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiDecoratorOptions } from './index';
 
-export type ApiDecoratorType = (opts?: ApiDecoratorOptions) => ReturnType<typeof applyDecorators>;
+export type ApiDecoratorType = (opts?: { required?: boolean }) => ReturnType<typeof applyDecorators>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@automapper/classes": "^8.7.7",
         "@automapper/core": "^8.7.7",
         "@automapper/nestjs": "^8.7.7",
+        "@automapper/types": "^6.3.1",
         "@aws-sdk/client-cognito-identity-provider": "^3.363.0",
         "@nestjs-cognito/auth": "^1.0.4",
         "@nestjs/common": "^10.0.2",
@@ -184,6 +185,14 @@
         "@automapper/core": "8.7.7",
         "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "@nestjs/core": "^7.0.0 || ^8.0.0  || ^9.0.0"
+      }
+    },
+    "node_modules/@automapper/types": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@automapper/types/-/types-6.3.1.tgz",
+      "integrity": "sha512-f0Y/Q4dVfKH6SQyzS5bPk+hZ4pSxzVNAOPEHdEAUe3gAc6ou43DCBYERuOaVSZ3zbWJbVt1KgWVNLP1dj9OIeg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@automapper/classes": "^8.7.7",
     "@automapper/core": "^8.7.7",
     "@automapper/nestjs": "^8.7.7",
+    "@automapper/types": "^6.3.1",
     "@aws-sdk/client-cognito-identity-provider": "^3.363.0",
     "@nestjs-cognito/auth": "^1.0.4",
     "@nestjs/common": "^10.0.2",


### PR DESCRIPTION
Update user-svc and core libs. Map object ids in entities to strings in user and user connection dtos. We don't want to pass object ids over the wire.