### PR TITLE
[Feature] Use the sub claim on the Cognito JWT token to identify users

### DIFF
--- a/.run/MediaAPI.e2e.run.xml
+++ b/.run/MediaAPI.e2e.run.xml
@@ -1,14 +1,17 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="MediaAPI.e2e" type="JavaScriptTestRunnerJest">
     <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
-    <node-options value="" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
-    <working-dir value="$PROJECT_DIR$/apps/media-svc-e2e" />
+    <working-dir value="$PROJECT_DIR$" />
     <envs>
       <env name="COGNITO_USER_EMAIL" value="lucas@bluecollardev.com" />
       <env name="COGNITO_USER_PASSWORD" value="Staging123!" />
     </envs>
-    <scope-kind value="ALL" />
+    <scope-kind value="SUITE" />
+    <test-file value="$PROJECT_DIR$/apps/media-svc-e2e/src/media-svc/media-svc.media-item.current.spec.ts" />
+    <test-names>
+      <test-name value="MediaItemApi.e2e" />
+    </test-names>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/MediaItemAPI.e2e.run.xml
+++ b/.run/MediaItemAPI.e2e.run.xml
@@ -1,7 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="MediaItemAPI.e2e" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
-    <node-interpreter value="project" />
-    <node-options value="" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.13.1/bin/node" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />
     <envs>

--- a/.run/PlaylistAPI.e2e.run.xml
+++ b/.run/PlaylistAPI.e2e.run.xml
@@ -1,7 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PlaylistAPI.e2e" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
-    <node-interpreter value="project" />
-    <node-options value="" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />
     <envs>

--- a/.run/PlaylistItemAPI.e2e.run.xml
+++ b/.run/PlaylistItemAPI.e2e.run.xml
@@ -1,7 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PlaylistItemAPI.e2e" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
-    <node-interpreter value="project" />
-    <node-options value="" />
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v16.14.2/bin/node" />
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />
     <envs>

--- a/apps/media-svc-e2e/src/media-svc/functions/media-item.ts
+++ b/apps/media-svc-e2e/src/media-svc/functions/media-item.ts
@@ -11,7 +11,7 @@ import { MediaItemDto } from '@mediashare/media-svc/src/app/modules/media-item/d
 
 export const createMediaItem = ({ baseUrl, token }) => (mediaItem) => {
   const dto = {
-    sub: randomUUID(),
+    // sub: randomUUID(),
     ...mediaItem,
   } as CreateMediaItemDto;
 

--- a/apps/media-svc-e2e/src/media-svc/media-svc.media-item.current.spec.ts
+++ b/apps/media-svc-e2e/src/media-svc/media-svc.media-item.current.spec.ts
@@ -1,5 +1,4 @@
 /* Ignore module boundaries, it's just our test scaffolding */
-import { initializeApp as initializeUserApi } from '@mediashare/user-svc-e2e/src/user-svc/functions/app';
 /* eslint-disable @nx/enforce-module-boundaries */
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
@@ -20,6 +19,7 @@ import {
 import { getBaseUrl, initializeApp, initializeDB } from './functions/app';
 import { defaultOptionsWithBearer, login } from './functions/auth';
 import { createAndValidateTestMediaItem, createMediaItem as createMediaItemFunction, getTestMediaItemId } from './functions/media-item';
+import { initializeApp as initializeUserApi } from '@mediashare/user-svc-e2e/src/user-svc/functions/app';
 
 describe('MediaItemAPI.e2e', () => {
   let app: INestApplication;

--- a/apps/media-svc-e2e/src/media-svc/media-svc.media-item.current.spec.ts
+++ b/apps/media-svc-e2e/src/media-svc/media-svc.media-item.current.spec.ts
@@ -1,4 +1,5 @@
 /* Ignore module boundaries, it's just our test scaffolding */
+import { initializeApp as initializeUserApi } from '@mediashare/user-svc-e2e/src/user-svc/functions/app';
 /* eslint-disable @nx/enforce-module-boundaries */
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
@@ -20,11 +21,11 @@ import { getBaseUrl, initializeApp, initializeDB } from './functions/app';
 import { defaultOptionsWithBearer, login } from './functions/auth';
 import { createAndValidateTestMediaItem, createMediaItem as createMediaItemFunction, getTestMediaItemId } from './functions/media-item';
 
-const userApiBaseUrl = `http://localhost:3000/api`;
-
 describe('MediaItemAPI.e2e', () => {
   let app: INestApplication;
   let baseUrl: string;
+  let userApi: INestApplication;
+  let userApiBaseUrl: string;
 
   let db: DataSource;
   let mediaItemRepository: MongoRepository<MediaItem>;
@@ -41,6 +42,9 @@ describe('MediaItemAPI.e2e', () => {
     const globalPrefix = 'api'
     app = await initializeApp(globalPrefix);
     baseUrl = await getBaseUrl(app, globalPrefix);
+
+    userApi = await initializeUserApi(globalPrefix);
+    userApiBaseUrl = await getBaseUrl(userApi, globalPrefix);
 
     db = await initializeDB([MediaItem, User]);
     mediaItemRepository = await db.getMongoRepository(MediaItem);

--- a/apps/media-svc-e2e/src/media-svc/media-svc.playlist-item.current.spec.ts
+++ b/apps/media-svc-e2e/src/media-svc/media-svc.playlist-item.current.spec.ts
@@ -30,12 +30,13 @@ import { PlaylistItemDto } from '@mediashare/media-svc/src/app/modules/playlist-
 import { PlaylistItem } from '@mediashare/media-svc/src/app/modules/playlist-item/entities/playlist-item.entity';
 import { MediaItem } from '@mediashare/media-svc/src/app/modules/media-item/entities/media-item.entity'
 import { User } from '@mediashare/user-svc/src/app/modules/user/entities/user.entity';
-
-const userApiBaseUrl = `http://localhost:3000/api`;
+import { initializeApp as initializeUserApi } from '@mediashare/user-svc-e2e/src/user-svc/functions/app';
 
 describe('PlaylistItemAPI.e2e', () => {
   let app: INestApplication;
   let baseUrl: string;
+  let userApi: INestApplication;
+  let userApiBaseUrl: string;
 
   let db: DataSource;
   let playlistItemRepository: MongoRepository<PlaylistItem>;
@@ -60,6 +61,9 @@ describe('PlaylistItemAPI.e2e', () => {
     const globalPrefix = 'api'
     app = await initializeApp(globalPrefix);
     baseUrl = await getBaseUrl(app, globalPrefix);
+
+    userApi = await initializeUserApi(globalPrefix);
+    userApiBaseUrl = await getBaseUrl(userApi, globalPrefix);
 
     db = await initializeDB([PlaylistItem, Playlist, MediaItem, User]);
     playlistItemRepository = await db.getMongoRepository(PlaylistItem);

--- a/apps/media-svc/src/app/core/guards/user.ts
+++ b/apps/media-svc/src/app/core/guards/user.ts
@@ -1,10 +1,10 @@
-import { COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY } from '@nestjs-cognito/auth';
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import axios, { AxiosRequestConfig } from 'axios';
+import { AxiosRequestConfig } from 'axios';
+import { getSub } from '@mediashare/core/utils/auth';
 
 export const USER_CONTEXT_PROPERTY = 'user';
 
-export function defaultOptionsWithBearer(token) {
+export function defaultOptionsWithBearer(token: string) {
   return {
     headers: {
       'authorization': `Bearer ${token}`
@@ -15,15 +15,9 @@ export function defaultOptionsWithBearer(token) {
 @Injectable()
 export class UserGuard implements CanActivate {
   async canActivate(ctx: ExecutionContext): Promise<boolean> {
-    const request = ctx.switchToHttp().getRequest();
-    const payload = request[COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY];
-    const idKey = 'sub';
-    const sub = payload[`cognito:${idKey}`] || payload[idKey]
     try {
-      // Forward request headers
-      const result = await axios.get(`http://localhost:3000/api/user/sub/${sub}`, { headers: { 'authorization': request.headers['authorization'] } } as any);
-      request[USER_CONTEXT_PROPERTY] = result.data;
-      return !!request[USER_CONTEXT_PROPERTY];
+      const request = ctx.switchToHttp().getRequest();
+      return !!getSub(request);
     } catch (err) {
       // TODO: Real error handling here plz!
       console.log(err);

--- a/apps/media-svc/src/app/modules/media-item/entities/media-item.entity.ts
+++ b/apps/media-svc/src/app/modules/media-item/entities/media-item.entity.ts
@@ -14,9 +14,9 @@ export class MediaItem extends ApiBaseEntity {
 
   @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
   // Explicitly set the name option: https://github.com/typeorm/typeorm/issues/4026
-  @ObjectIdColumn({ name: 'userId', nullable: false, unique: false })
+  @Column({ nullable: false, type: 'text' })
   @Index('userId', { unique: false })
-  userId: ObjectId;
+  userId: string;
 
   @AutoMap()
   @Column({ nullable: false, type: 'text' })

--- a/apps/media-svc/src/app/modules/media-item/mappers/automapper.profile.ts
+++ b/apps/media-svc/src/app/modules/media-item/mappers/automapper.profile.ts
@@ -13,7 +13,6 @@ export const mediaItemToMediaItemDtoMappingFactory = (mapper) => createMap(
   MediaItem,
   MediaItemDto,
   forMember((dest: MediaItemDto) => dest._id, convertUsing(objectIdToStringConverter as never, (source: MediaItem) => source._id)),
-  forMember((dest: MediaItemDto) => dest.userId, convertUsing(objectIdToStringConverter as never, (source: MediaItem) => source.userId)),
 );
 
 export const createMediaItemDtoToMediaItemMappingFactory = (mapper) => createMap(
@@ -21,7 +20,6 @@ export const createMediaItemDtoToMediaItemMappingFactory = (mapper) => createMap
   CreateMediaItemDto,
   MediaItem,
   forMember((dest: MediaItem) => dest._id, ignore()),
-  forMember((dest: MediaItem) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: CreateMediaItemDto) => source.userId)),
 );
 
 export const updateMediaItemDtoToMediaItemMappingFactory = (mapper) => createMap(
@@ -29,7 +27,6 @@ export const updateMediaItemDtoToMediaItemMappingFactory = (mapper) => createMap
   UpdateMediaItemDto,
   MediaItem,
   forMember((dest: MediaItem) => dest._id, convertUsing(stringToObjectIdConverter as never, (source: MediaItemDto) => source._id)),
-  forMember((dest: MediaItem) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: MediaItemDto) => source.userId)),
 );
 
 @Injectable()

--- a/apps/media-svc/src/app/modules/media-item/media-item.service.ts
+++ b/apps/media-svc/src/app/modules/media-item/media-item.service.ts
@@ -69,10 +69,10 @@ export class MediaItemDataService extends FilterableDataService<MediaItem, Mongo
           $match: query
             ? {
               $text: { $search: query },
-              $and: [{ createdBy: ObjectIdGuard(userId) }],
+              $and: [{ createdBy: userId }],
             }
             : {
-              $and: [{ createdBy: ObjectIdGuard(userId) }],
+              $and: [{ createdBy: userId }],
             },
         },
       ]);
@@ -133,21 +133,9 @@ export class MediaItemDataService extends FilterableDataService<MediaItem, Mongo
 
   protected buildFields() {
     return [
-      { $lookup: { from: 'user', localField: 'userId', foreignField: '_id', as: 'author' } },
       // { $lookup: { from: 'share_item', localField: '_id', foreignField: 'mediaId', as: 'shareItems' } },
       // { $lookup: { from: 'view_item', localField: '_id', foreignField: 'mediaId', as: 'viewItems' } },
       // { $lookup: { from: 'like_item', localField: '_id', foreignField: 'mediaId', as: 'likeItems' } },
-      { $unwind: { path: '$author' } },
-      {
-        $addFields: {
-          authorProfile: {
-            authorId: '$author._id',
-            authorName: { $concat: ['$author.firstName', ' ', '$author.lastName'] },
-            authorUsername: '$author.username',
-            authorImage: '$author.imageSrc',
-          },
-        },
-      },
     ];
   }
 
@@ -158,10 +146,7 @@ export class MediaItemDataService extends FilterableDataService<MediaItem, Mongo
           $mergeObjects: [
             {
               _id: '$_id',
-              userId: '$author._id',
-              username: '$author.username',
-              author: '$author',
-              authorProfile: '$authorProfile',
+              userId: '$userId',
               title: '$title',
               description: '$description',
               uri: '$uri',
@@ -171,7 +156,7 @@ export class MediaItemDataService extends FilterableDataService<MediaItem, Mongo
               // shareCount: { $size: '$shareItems' },
               // likesCount: { $size: '$likeItems' },
               // viewCount: { $size: '$viewItems' },
-              createdBy: '$author._id',
+              createdBy: '$createdBy',
               createdAt: '$createdAt',
               updatedDate: '$updatedDate',
             },

--- a/apps/media-svc/src/app/modules/playlist-item/entities/playlist-item.entity.ts
+++ b/apps/media-svc/src/app/modules/playlist-item/entities/playlist-item.entity.ts
@@ -20,9 +20,9 @@ export class PlaylistItem extends ApiBaseEntity {
   mediaId: ObjectId;
 
   @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
-  @ObjectIdColumn({ name: 'userId', nullable: false, unique: false })
+  @Column({ nullable: false, type: 'text' })
   @Index('userId', { unique: false })
-  userId: ObjectId;
+  userId: string;
 
   @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
   @ObjectIdColumn({ name: 'createdBy', nullable: true, unique: false })

--- a/apps/media-svc/src/app/modules/playlist-item/functors/map-playlist-item.functor.ts
+++ b/apps/media-svc/src/app/modules/playlist-item/functors/map-playlist-item.functor.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb';
 
-function mapPlaylistItems(ids: Readonly<string[]>, params: { userId: ObjectId; playlistId: ObjectId }) {
+function mapPlaylistItems(ids: Readonly<string[]>, params: { userId: string; playlistId: ObjectId }) {
   const { userId, playlistId } = params;
 
   return ids.map((id) => ({

--- a/apps/media-svc/src/app/modules/playlist-item/mappers/automapper.profile.ts
+++ b/apps/media-svc/src/app/modules/playlist-item/mappers/automapper.profile.ts
@@ -15,8 +15,6 @@ export const playlistItemToPlaylistItemDtoMappingFactory = (mapper) => createMap
   forMember((dest: PlaylistItemDto) => dest._id, convertUsing(objectIdToStringConverter as never, (source: PlaylistItem) => source._id)),
   forMember((dest: PlaylistItemDto) => dest.playlistId, convertUsing(objectIdToStringConverter as never, (source: PlaylistItem) => source.playlistId)),
   forMember((dest: PlaylistItemDto) => dest.mediaId, convertUsing(objectIdToStringConverter as never, (source: PlaylistItem) => source.mediaId)),
-  forMember((dest: PlaylistItemDto) => dest.userId, convertUsing(objectIdToStringConverter as never, (source: PlaylistItem) => source.userId)),
-  forMember((dest: PlaylistItemDto) => dest.createdBy, convertUsing(objectIdToStringConverter as never, (source: PlaylistItem) => source.createdBy)),
 );
 
 export const createPlaylistItemDtoToPlaylistItemMappingFactory = (mapper) => createMap(
@@ -26,8 +24,6 @@ export const createPlaylistItemDtoToPlaylistItemMappingFactory = (mapper) => cre
   forMember((dest: PlaylistItem) => dest._id, ignore()),
   forMember((dest: PlaylistItem) => dest.playlistId, convertUsing(stringToObjectIdConverter as never, (source: CreatePlaylistItemDto) => source.playlistId)),
   forMember((dest: PlaylistItem) => dest.mediaId, convertUsing(stringToObjectIdConverter as never, (source: CreatePlaylistItemDto) => source.mediaId)),
-  forMember((dest: PlaylistItem) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: CreatePlaylistItemDto) => source.userId)),
-  forMember((dest: PlaylistItem) => dest.createdBy, convertUsing(stringToObjectIdConverter as never, (source: CreatePlaylistItemDto) => source.createdBy)),
 );
 
 export const updatePlaylistItemDtoToPlaylistItemMappingFactory = (mapper) => createMap(
@@ -37,8 +33,6 @@ export const updatePlaylistItemDtoToPlaylistItemMappingFactory = (mapper) => cre
   forMember((dest: PlaylistItem) => dest._id, convertUsing(stringToObjectIdConverter as never, (source: UpdatePlaylistItemDto) => source._id)),
   forMember((dest: PlaylistItem) => dest.playlistId, convertUsing(stringToObjectIdConverter as never, (source: UpdatePlaylistItemDto) => source.playlistId)),
   forMember((dest: PlaylistItem) => dest.mediaId, convertUsing(stringToObjectIdConverter as never, (source: UpdatePlaylistItemDto) => source.mediaId)),
-  forMember((dest: PlaylistItem) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: UpdatePlaylistItemDto) => source.userId)),
-  forMember((dest: PlaylistItem) => dest.createdBy, convertUsing(stringToObjectIdConverter as never, (source: UpdatePlaylistItemDto) => source.createdBy)),
 );
 
 @Injectable()

--- a/apps/media-svc/src/app/modules/playlist-item/playlist-item.controller.ts
+++ b/apps/media-svc/src/app/modules/playlist-item/playlist-item.controller.ts
@@ -5,7 +5,7 @@ import { ApiBearerAuth, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { RouteTokens } from '../../core/constants';
 import { MEDIA_VISIBILITY } from '../../core/models';
-import { GetUser } from '@mediashare/core/decorators/user.decorator';
+import { GetClaims } from '@mediashare/core/decorators/auth.decorator';
 import { UserGuard } from '../../core/guards';
 import { PlaylistItemGetResponse, PlaylistItemPostResponse, PlaylistItemPutResponse, PlaylistItemShareResponse } from './playlist-item.decorator';
 import { PlaylistItemService } from './playlist-item.service';
@@ -34,7 +34,7 @@ export class PlaylistItemController {
   @ApiBearerAuth()
   @Post()
   @PlaylistItemPostResponse()
-  async create(@Res() res: Response, @Body() createPlaylistItemDto: CreatePlaylistItemDto, @GetUser('_id') createdBy) {
+  async create(@Res() res: Response, @Body() createPlaylistItemDto: CreatePlaylistItemDto, @GetClaims('sub') createdBy) {
     try {
       const playlistId = createPlaylistItemDto?.playlistId;
       const mediaId = createPlaylistItemDto?.mediaId;
@@ -95,7 +95,7 @@ export class PlaylistItemController {
     @Res() res: Response,
     @Param('playlistItemId') playlistItemId: string,
     @Param(RouteTokens.userId) userId: string,
-    @GetUser('_id') createdBy: string,
+    @GetClaims('sub') createdBy: string,
   ) {
     try {
       const result = await this.playlistItemService.findOne(playlistItemId);

--- a/apps/media-svc/src/app/modules/playlist-item/playlist-item.service.ts
+++ b/apps/media-svc/src/app/modules/playlist-item/playlist-item.service.ts
@@ -70,10 +70,10 @@ export class PlaylistItemDataService extends FilterableDataService<PlaylistItem,
           $match: query
             ? {
               $text: { $search: query },
-              $and: [{ createdBy: ObjectIdGuard(userId) }],
+              $and: [{ createdBy: userId }],
             }
             : {
-              $and: [{ createdBy: ObjectIdGuard(userId) }],
+              $and: [{ createdBy: userId }],
             },
         },
       ]);
@@ -134,11 +134,9 @@ export class PlaylistItemDataService extends FilterableDataService<PlaylistItem,
 
   protected buildFields() {
     return [
-      // { $lookup: { from: 'user', localField: 'createdBy', foreignField: '_id', as: 'author' } },
       // { $lookup: { from: 'share_item', localField: '_id', foreignField: 'playlistItemId', as: 'shareItems' } },
       // { $lookup: { from: 'view_item', localField: '_id', foreignField: 'playlistItemId', as: 'viewItems' } },
       // { $lookup: { from: 'like_item', localField: '_id', foreignField: 'playlistItemId', as: 'likeItems' } },
-      // { $unwind: { path: '$author' } },
     ];
   }
 
@@ -151,10 +149,7 @@ export class PlaylistItemDataService extends FilterableDataService<PlaylistItem,
               _id: '$_id',
               playlistId: '$playlistId',
               // mediaId: '$mediaId',
-              // userId: '$author._id',
-              // username: '$author.username',
-              // author: '$author',
-              // authorProfile: '$authorProfile',
+              userId: '$userId',
               title: '$title',
               description: '$description',
               sortIndex: '$sortIndex',
@@ -166,7 +161,7 @@ export class PlaylistItemDataService extends FilterableDataService<PlaylistItem,
               // likesCount: { $size: '$likeItems' },
               // viewCount: { $size: '$viewItems' },
               // viewCount: { $size: '$viewItems' },
-              // createdBy: '$author._id',
+              createdBy: '$createdBy',
               createdAt: '$createdAt',
               updatedDate: '$updatedDate',
             },

--- a/apps/media-svc/src/app/modules/playlist/mappers/automapper.profile.ts
+++ b/apps/media-svc/src/app/modules/playlist/mappers/automapper.profile.ts
@@ -28,7 +28,6 @@ export const updatePlaylistDtoToPlaylistMappingFactory = (mapper) => createMap(
   UpdatePlaylistDto,
   Playlist,
   forMember((dest: Playlist) => dest._id, convertUsing(stringToObjectIdConverter as never, (source: UpdatePlaylistDto) => source._id)),
-  // forMember((dest: Playlist) => dest.createdBy, convertUsing(stringToObjectIdConverter as never, (source: PlaylistDto) => source.createdBy)),
 );
 
 @Injectable()

--- a/apps/media-svc/src/app/modules/playlist/playlist.service.ts
+++ b/apps/media-svc/src/app/modules/playlist/playlist.service.ts
@@ -77,10 +77,10 @@ export class PlaylistDataService extends FilterableDataService<Playlist, MongoRe
           $match: query
             ? {
               $text: { $search: query },
-              $and: [{ createdBy: ObjectIdGuard(userId) }],
+              $and: [{ createdBy: userId }],
             }
             : {
-              $and: [{ createdBy: ObjectIdGuard(userId) }],
+              $and: [{ createdBy: userId }],
             },
         },
       ]);
@@ -141,23 +141,11 @@ export class PlaylistDataService extends FilterableDataService<Playlist, MongoRe
 
   protected buildFields() {
     return [
-      // { $lookup: { from: 'user', localField: 'userId', foreignField: '_id', as: 'author' } },
       // { $lookup: { from: 'media_item', localField: 'mediaIds', foreignField: '_id', as: 'mediaItems' } },
       // { $lookup: { from: 'playlist_item', localField: '_id', foreignField: 'playlistId', as: 'playlistItems' } },
       // { $lookup: { from: 'share_item', localField: '_id', foreignField: 'playlistId', as: 'shareItems' } },
       // { $lookup: { from: 'view_item', localField: '_id', foreignField: 'playlistId', as: 'viewItems' } },
       // { $lookup: { from: 'like_item', localField: '_id', foreignField: 'playlistId', as: 'likeItems' } },
-      // { $unwind: { path: '$author' } },
-      /* {
-        $addFields: {
-          authorProfile: {
-            authorId: '$author._id',
-            authorName: { $concat: ['$author.firstName', ' ', '$author.lastName'] },
-            authorUsername: '$author.username',
-            authorImage: '$author.imageSrc',
-          },
-        },
-      }, */
     ];
   }
 
@@ -168,9 +156,7 @@ export class PlaylistDataService extends FilterableDataService<Playlist, MongoRe
           $mergeObjects: [
             {
               _id: '$_id',
-              // userId: '$author._id',
-              // username: '$author.username',
-              // authorProfile: '$authorProfile',
+              userId: '$userId',
               title: '$title',
               description: '$description',
               imageSrc: '$imageSrc',
@@ -181,7 +167,7 @@ export class PlaylistDataService extends FilterableDataService<Playlist, MongoRe
               // shareCount: { $size: '$shareItems' },
               // likesCount: { $size: '$likeItems' },
               // viewCount: { $size: '$viewItems' },
-              // createdBy: '$author._id',
+              createdBy: '$createdBy',
               createdAt: '$createdAt',
               updatedDate: '$updatedDate',
             },
@@ -210,7 +196,7 @@ export class PlaylistService {
       description,
       imageSrc,
       tags,
-      createdBy: ObjectIdGuard(createdBy),
+      createdBy,
       mediaIds: mediaIds.map((id) => ObjectIdGuard(id)),
       cloneOf,
     } as any);

--- a/apps/media-svc/src/app/modules/share-item/entities/share-item.entity.ts
+++ b/apps/media-svc/src/app/modules/share-item/entities/share-item.entity.ts
@@ -7,9 +7,9 @@ import { ApiBaseEntity } from '@mediashare/core/entities/base.entity';
 @Entity('share_item')
 export class ShareItem extends ApiBaseEntity {
   @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
-  @ObjectIdColumn({ name: 'userId', nullable: false, unique: false })
+  @Column({ nullable: false, type: 'text' })
   @Index('userId', { unique: false })
-  userId: ObjectId;
+  userId: string;
 
   @AutoMap({ typeFn: () => ObjectId } as AutoMapOptions)
   @ObjectIdColumn({ name: 'playlistId', nullable: true, unique: false })

--- a/apps/media-svc/src/app/modules/share-item/mappers/automapper.profile.ts
+++ b/apps/media-svc/src/app/modules/share-item/mappers/automapper.profile.ts
@@ -12,7 +12,6 @@ export const createMediaShareItemDtoToShareItemMappingFactory = (mapper) => crea
   CreateMediaShareItemDto,
   ShareItem,
   forMember((dest: ShareItem) => dest._id, ignore()),
-  forMember((dest: ShareItem) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: CreateMediaShareItemDto) => source.userId)),
   forMember((dest: ShareItem) => dest.playlistId, convertUsing(stringToObjectIdConverter as never, (source: CreateMediaShareItemDto) => source.playlistId)),
   forMember((dest: ShareItem) => dest.mediaId, convertUsing(stringToObjectIdConverter as never, (source: CreateMediaShareItemDto) => source.mediaId)),
 );
@@ -22,7 +21,6 @@ export const createPlaylistShareItemDtoToShareItemMappingFactory = (mapper) => c
   CreatePlaylistShareItemDto,
   ShareItem,
   forMember((dest: ShareItem) => dest._id, ignore()),
-  forMember((dest: ShareItem) => dest.userId, convertUsing(stringToObjectIdConverter as never, (source: CreatePlaylistShareItemDto) => source.userId)),
   forMember((dest: ShareItem) => dest.playlistId, convertUsing(stringToObjectIdConverter as never, (source: CreatePlaylistShareItemDto) => source.playlistId)),
   forMember((dest: ShareItem) => dest.mediaId, convertUsing(stringToObjectIdConverter as never, (source: CreatePlaylistShareItemDto) => source.mediaId)),
 );

--- a/apps/media-svc/src/app/modules/share-item/share-item.controller.ts
+++ b/apps/media-svc/src/app/modules/share-item/share-item.controller.ts
@@ -1,7 +1,7 @@
 import { AuthenticationGuard } from '@nestjs-cognito/auth';
 import { Controller, Param, HttpCode, UseGuards, HttpStatus, Get, Delete, Post, Body } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { GetUser } from '@mediashare/core/decorators/user.decorator';
+import { GetClaims } from '@mediashare/core/decorators/auth.decorator';
 import { RouteTokens } from '../../core/constants';
 import { ShareItemService } from './share-item.service';
 import { ShareItemsByUserIdDto, ShareItemsDto, ShareItemsResponseDto } from './dto/share-item.dto';
@@ -9,7 +9,6 @@ import { ShareItemGetResponse } from './share-item.decorator';
 import { ShareItem } from './entities/share-item.entity';
 import { MediaItemDto } from '../media-item/dto/media-item.dto';
 import { PlaylistDto } from '../playlist/dto/playlist.dto';
-import { UserGuard } from '@mediashare/core/guards/user.guard';
 
 @ApiTags('share-items')
 @Controller('share-items')
@@ -20,7 +19,7 @@ export class ShareItemController {
   @ApiBearerAuth()
   @Get('shared-by-user')
   @ShareItemGetResponse({ type: ShareItemsResponseDto, isArray: true })
-  async findItemsSharedByUser(@GetUser('_id') userId: string) {
+  async findItemsSharedByUser(@GetClaims('sub') userId: string) {
     return await this.shareItemService.getItemsSharedByUser(userId);
   }
 
@@ -28,7 +27,7 @@ export class ShareItemController {
   @ApiBearerAuth()
   @Get('shared-by-user/media-items')
   @ShareItemGetResponse({ type: MediaItemDto, isArray: true })
-  async findMediaItemsSharedByUser(@GetUser('_id') userId: string) {
+  async findMediaItemsSharedByUser(@GetClaims('sub') userId: string) {
     return await this.shareItemService.getMediaItemsSharedByUser(userId);
   }
 
@@ -36,7 +35,7 @@ export class ShareItemController {
   @ApiBearerAuth()
   @Get('shared-by-user/playlists')
   @ShareItemGetResponse({ type: PlaylistDto, isArray: true })
-  async findPlaylistsSharedByUser(@GetUser('_id') userId: string) {
+  async findPlaylistsSharedByUser(@GetClaims('sub') userId: string) {
     return await this.shareItemService.getPlaylistsSharedByUser(userId);
   }
 
@@ -44,7 +43,7 @@ export class ShareItemController {
   @ApiBearerAuth()
   @Get('shared-with-user')
   @ShareItemGetResponse({ type: ShareItemsResponseDto, isArray: false })
-  async findItemsSharedWithUser(@GetUser('_id') userId: string) {
+  async findItemsSharedWithUser(@GetClaims('sub') userId: string) {
     return await this.shareItemService.getItemsSharedWithUser(userId);
   }
 
@@ -52,7 +51,7 @@ export class ShareItemController {
   @ApiBearerAuth()
   @Get('shared-with-user/media-items')
   @ShareItemGetResponse({ type: MediaItemDto, isArray: true })
-  async findMediaItemsSharedWithUser(@GetUser('_id') userId: string) {
+  async findMediaItemsSharedWithUser(@GetClaims('sub') userId: string) {
     return await this.shareItemService.getMediaItemsSharedWithUser(userId);
   }
 
@@ -60,7 +59,7 @@ export class ShareItemController {
   @ApiBearerAuth()
   @Get('shared-with-user/playlists')
   @ShareItemGetResponse({ type: PlaylistDto, isArray: true })
-  async findPlaylistsSharedWithUser(@GetUser('_id') userId: string) {
+  async findPlaylistsSharedWithUser(@GetClaims('sub') userId: string) {
     return await this.shareItemService.getPlaylistsSharedWithUser(userId);
   }
 

--- a/apps/user-svc/src/app/modules/user/user.guard.ts
+++ b/apps/user-svc/src/app/modules/user/user.guard.ts
@@ -15,6 +15,6 @@ export class UserGuard implements CanActivate {
     const sub = payload[`cognito:${idKey}`] || payload[idKey]
 
     request[USER_CONTEXT_PROPERTY] = await this.userSvc.findByQuery({ where: { sub } });
-    return !!request.user;
+    return !!request[USER_CONTEXT_PROPERTY];
   }
 }

--- a/libs/core/src/lib/decorators/auth.decorator.ts
+++ b/libs/core/src/lib/decorators/auth.decorator.ts
@@ -1,0 +1,23 @@
+import { defaultSubClaimName, getAuthCtx } from '@mediashare/core/utils/auth';
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const GetClaims = createParamDecorator(
+  (keys: string | string[], ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const authCtx = getAuthCtx(request);
+
+    if (!keys) {
+      return authCtx;
+    }
+
+    if (Array.isArray(keys)) {
+      return keys.reduce((result, key) => {
+        // @ts-ignore
+        result[key] = authCtx[key];
+        return result;
+      }, {});
+    }
+
+    return authCtx[keys];
+  }
+);

--- a/libs/core/src/lib/decorators/user.decorator.ts
+++ b/libs/core/src/lib/decorators/user.decorator.ts
@@ -2,6 +2,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 export const USER_CONTEXT_PROPERTY = 'user';
 
 /**
+ *
  * Decorator that can be used to inject the cognito user into a controller.
  * @param {string} [propertyName] The name of the property to inject the user into.
  * @returns {(target: object, key: string | symbol, descriptor: TypedPropertyDescriptor<any>) => any}
@@ -20,6 +21,7 @@ export const GetUser = createParamDecorator(
 
     if (Array.isArray(data)) {
       return data.reduce((result, key) => {
+        // @ts-ignore
         result[key] = user[key];
         return result;
       }, {});

--- a/libs/core/src/lib/utils/auth.ts
+++ b/libs/core/src/lib/utils/auth.ts
@@ -1,0 +1,19 @@
+import { COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY } from '@nestjs-cognito/auth';
+
+export const defaultSubClaimName = 'sub';
+export function getSub(request: any) {
+  return getClaim(request, defaultSubClaimName);
+}
+
+export function getClaim(request: any, claimKey: string) {
+  const payload = getAuthCtx(request);
+  return payload[`cognito:${claimKey}`] || payload[claimKey];
+}
+
+export function getAuthCtx(request: any) {
+  return request[COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY];
+}
+
+export function setAuthCtxProperty(request: any, property: any): void {
+  request[COGNITO_JWT_PAYLOAD_CONTEXT_PROPERTY] = property;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,6 +22,7 @@
       "@mediashare/shared/*": ["libs/shared/src/lib/*"],
       "@mediashare/utility": ["libs/utility/src/index.ts"],
       "@mediashare/user-svc/*": ["apps/user-svc/*"],
+      "@mediashare/user-svc-e2e/*": ["apps/user-svc-e2e/*"],
       "@mediashare/media-svc/*": ["apps/media-svc/*"]
     }
   },


### PR DESCRIPTION
Use the sub claim on the Cognito JWT token to identify users, and when storing userIds. This way we don't have to call the User API on every request to get the user. Fix corresponding tests.